### PR TITLE
Fixed bug.

### DIFF
--- a/app/src/main/java/ru/internship/gifsearcher/ui/screens/details_screen/DetailsScreen.kt
+++ b/app/src/main/java/ru/internship/gifsearcher/ui/screens/details_screen/DetailsScreen.kt
@@ -125,7 +125,7 @@ fun DetailsScreen(
                     }
 
                     Button(
-                        onClick = { navController.navigateUp() },
+                        onClick = { navController.popBackStack() },
                         modifier = Modifier.padding(top = 16.dp)
                     ) {
                         Text(

--- a/app/src/main/java/ru/internship/gifsearcher/ui/screens/main_screen/MainScreen.kt
+++ b/app/src/main/java/ru/internship/gifsearcher/ui/screens/main_screen/MainScreen.kt
@@ -1,5 +1,6 @@
 package ru.internship.gifsearcher.ui.screens.main_screen
 
+import android.util.Log
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -106,7 +107,7 @@ fun MainScreen(
             } else {
                 /**Current list of gifs.*/
                 val giffsData = vm.gifData.observeAsState()
-
+                Log.e("BUGFIX", "giffsData is ${giffsData.value?.data?.size}")
                 if (giffsData.value?.data.isNullOrEmpty())
                     Box(
                         modifier = Modifier

--- a/app/src/main/java/ru/internship/gifsearcher/vm/MainViewModel.kt
+++ b/app/src/main/java/ru/internship/gifsearcher/vm/MainViewModel.kt
@@ -104,7 +104,9 @@ class MainViewModel @Inject constructor(
         onLoadSuccess: () -> Unit = {},
         onLoadFailure: () -> Unit = {}
     ) {
-        _tagText.value = value
+        if (_tagText.value == null)
+            _tagText.value = value
+        Log.e("BUGFIX", "_tagText = ${_tagText.value}")
         currentPage = 0
         _isPageLoading.value = false
         _loadingFailed.value = false
@@ -113,7 +115,7 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             if (value.isNotEmpty())
                 getNewSearchedGifs(
-                    value = value,
+                    value = _tagText.value!!,
                     onLoadSuccess = onLoadSuccess,
                     onLoadFailure = onLoadFailure
                 )
@@ -130,11 +132,13 @@ class MainViewModel @Inject constructor(
     fun loadNextSearchedGifsPage(
         value: String
     ) {
+        if (_tagText.value == null)
+            _tagText.value = value
         if (!isNewCardsRequested)
             viewModelScope.launch {
                 isNewCardsRequested = true
                 getNewSearchedGifs(
-                    value = value,
+                    value = _tagText.value!!,
                     onLoadSuccess = {
                         isNewCardsRequested = false
                     }
@@ -240,7 +244,7 @@ class MainViewModel @Inject constructor(
         currentPage = 0
     }
 
-    fun LoadingFailed(){
+    fun LoadingFailed() {
         _loadingFailed.value = true
     }
 }


### PR DESCRIPTION
It occurs that if user closes details screen from search new list of gifs will created from null value (value of search query), so it's empty.